### PR TITLE
Add openzeppelin subgraphs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "@amxx/graphprotocol-utils": "^1.0.0-alpha.11",
-    "@openzeppelin/contracts": "^4.2.0"
+    "@openzeppelin/contracts": "^4.2.0",
+    "@openzeppelin/subgraphs": "^0.1.0"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.21.0",


### PR DESCRIPTION
Ran into the same issue as #3, I think it just needs the `@openzeppelin/subgraphs` dependency to be added.