### PR TITLE
Fix `fetchERC721`

### DIFF
--- a/src/fetch/erc721.ts
+++ b/src/fetch/erc721.ts
@@ -47,7 +47,7 @@ export function fetchERC721(address: Address): ERC721Contract {
 		let contract = ERC721Contract.load(account.id)
 
 		if (contract == null) {
-			let contract              = new ERC721Contract(account.id)
+			contract                  = new ERC721Contract(account.id)
 			let try_name              = erc721.try_name()
 			let try_symbol            = erc721.try_symbol()
 			contract.name             = try_name.reverted   ? '' : try_name.value


### PR DESCRIPTION
Remove re-declaration of `contract`, so that the newly created instance is returned by the function.

This bug manifests itself as the subgraph failing to index transfer events.

**Steps to reproduce the bug**
1. Deploy a sample mintable ERC721 contract generated from the [OZ wizard](https://docs.openzeppelin.com/contracts/4.x/wizard), mint a few tokens.
2. Deploy the subgraph.
3. Run the following query: https://gist.github.com/freeatnet/99884eb7b698fe4a010bb1744ff5d812#file-erc721-graphql

**Expected**
`erc721Contracts` returns the deployed contract, along with its name and symbol; `erc721Transfers` field returns minting transactions; `accounts.ERC721tokens` and `accounts.ERC721transferToEvent` fields are populated appropriately.

**Observed**
`erc721Contracts` returns the deployed contract, along with its name and symbol; *however*, `erc721Transfers`, `accounts.ERC721tokens`, and `accounts.ERC721transferToEvent` are empty.