### PR TITLE
Fix: Entity IDs collision due to `immutable: true` inclusion

### DIFF
--- a/src/datasources/accesscontrol.ts
+++ b/src/datasources/accesscontrol.ts
@@ -1,7 +1,6 @@
 import { store } from '@graphprotocol/graph-ts'
 
 import {
-	AccessControlRole,
 	AccessControlRoleMember,
 	RoleAdminChanged,
 	RoleGranted,
@@ -38,7 +37,10 @@ export function handleRoleAdminChanged(event: RoleAdminChangedEvent): void {
 	accesscontrolrole.admin = admin.id
 	accesscontrolrole.save()
 
-	let ev               = new RoleAdminChanged(events.id(event))
+	let roleAdminId      = events.id(event)
+	let ev               = RoleAdminChanged.load(roleAdminId)
+	if (ev !== null)     return
+	ev                   = new RoleAdminChanged(roleAdminId)
 	ev.emitter           = contract.id
 	ev.transaction       = transactions.log(event).id
 	ev.timestamp         = event.block.timestamp
@@ -59,13 +61,16 @@ export function handleRoleGranted(event: RoleGrantedEvent): void {
 	accesscontrolrolemember.account           = account.id
 	accesscontrolrolemember.save()
 
-	let ev         = new RoleGranted(events.id(event))
-	ev.emitter     = contract.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.role        = accesscontrolrole.id
-	ev.account     = account.id
-	ev.sender      = sender.id
+	let roleGrantedId = events.id(event)
+	let ev            = RoleGranted.load(roleGrantedId)
+	if (ev !== null)  return
+	ev                = new RoleGranted(roleGrantedId)
+	ev.emitter     	  = contract.id
+	ev.transaction 	  = transactions.log(event).id
+	ev.timestamp   	  = event.block.timestamp
+	ev.role        	  = accesscontrolrole.id
+	ev.account     	  = account.id
+	ev.sender      	  = sender.id
 	ev.save()
 }
 
@@ -77,12 +82,15 @@ export function handleRoleRevoked(event: RoleRevokedEvent): void {
 
 	store.remove('AccessControlRoleMember', accesscontrolrole.id.concat('/').concat(account.id.toHex()))
 
-	let ev         = new RoleRevoked(events.id(event))
-	ev.emitter     = contract.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.role        = accesscontrolrole.id
-	ev.account     = account.id
-	ev.sender      = sender.id
+	let roleRevokedId = events.id(event)
+	let ev            = RoleRevoked.load(roleRevokedId)
+	if (ev !== null)  return 
+	ev                = new RoleRevoked(roleRevokedId)
+	ev.emitter     	  = contract.id
+	ev.transaction 	  = transactions.log(event).id
+	ev.timestamp   	  = event.block.timestamp
+	ev.role        	  = accesscontrolrole.id
+	ev.account     	  = account.id
+	ev.sender      	  = sender.id
 	ev.save()
 }

--- a/src/datasources/erc1155.ts
+++ b/src/datasources/erc1155.ts
@@ -46,16 +46,19 @@ function registerTransfer(
 	value:    BigInt)
 : void
 {
-	let token      = fetchERC1155Token(contract, id)
-	let ev         = new ERC1155Transfer(events.id(event).concat(suffix))
-	ev.emitter     = token.contract
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.contract    = contract.id
-	ev.token       = token.id
-	ev.operator    = operator.id
-	ev.value       = decimals.toDecimals(value)
-	ev.valueExact  = value
+	let token             = fetchERC1155Token(contract, id)
+	let ERC1155TransferId = events.id(event).concat(suffix)
+	let ev                = ERC1155Transfer.load(ERC1155TransferId)
+	if (ev !== null)      return
+	ev                    = new ERC1155Transfer(ERC1155TransferId)
+	ev.emitter            = token.contract
+	ev.transaction        = transactions.log(event).id
+	ev.timestamp          = event.block.timestamp
+	ev.contract           = contract.id
+	ev.token              = token.id
+	ev.operator           = operator.id
+	ev.value              = decimals.toDecimals(value)
+	ev.valueExact         = value
 
 	if (from.id == Address.zero()) {
 		let totalSupply        = fetchERC1155Balance(token, null)
@@ -123,7 +126,7 @@ export function handleTransferBatch(event: TransferBatchEvent): void
 	// If this equality doesn't hold (some devs actually don't follox the ERC specifications) then we just can't make
 	// sens of what is happening. Don't try to make something out of stupid code, and just throw the event. This
 	// contract doesn't follow the standard anyway.
-	if(ids.length == values.length)
+	if (ids.length == values.length)
 	{
 		for (let i = 0;  i < ids.length; ++i)
 		{

--- a/src/datasources/erc1967upgrade.ts
+++ b/src/datasources/erc1967upgrade.ts
@@ -25,11 +25,14 @@ export function handleAdminChanged(event: AdminChangedEvent): void {
 	contract.erc1967Admin = implementation.id
 	contract.save()
 
-	let ev         = new ERC1967AdminChanged(events.id(event))
-	ev.emitter     = contract.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.admin       = implementation.id
+	let ERC1967AdminChangedId = events.id(event)
+	let ev                    = ERC1967AdminChanged.load(ERC1967AdminChangedId)
+	if (ev !== null)          return
+	ev                        = new ERC1967AdminChanged(ERC1967AdminChangedId)
+	ev.emitter                = contract.id
+	ev.transaction            = transactions.log(event).id
+	ev.timestamp              = event.block.timestamp
+	ev.admin                  = implementation.id
 	ev.save()
 }
 export function handleBeaconUpgraded(event: BeaconUpgradedEvent): void {
@@ -38,11 +41,14 @@ export function handleBeaconUpgraded(event: BeaconUpgradedEvent): void {
 	contract.erc1967Beacon = beacon.id
 	contract.save()
 
-	let ev         = new ERC1967BeaconUpgraded(events.id(event))
-	ev.emitter     = contract.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.beacon      = beacon.id
+	let ERC1967BeaconUpgradedId = events.id(event)
+	let ev                      = ERC1967BeaconUpgraded.load(ERC1967BeaconUpgradedId)
+	if (ev !== null)            return
+	ev                          = new ERC1967BeaconUpgraded(ERC1967BeaconUpgradedId)
+	ev.emitter                  = contract.id
+	ev.transaction              = transactions.log(event).id
+	ev.timestamp                = event.block.timestamp
+	ev.beacon                   = beacon.id
 	ev.save()
 }
 export function handleUpgraded(event: UpgradedEvent): void {
@@ -51,10 +57,13 @@ export function handleUpgraded(event: UpgradedEvent): void {
 	contract.erc1967Implementation = admin.id
 	contract.save()
 
-	let ev            = new ERC1967ImplementationUpgraded(events.id(event))
-	ev.emitter        = contract.id
-	ev.transaction    = transactions.log(event).id
-	ev.timestamp      = event.block.timestamp
-	ev.implementation = admin.id
+	let ERC1967ImplementationUpgradedId = events.id(event)
+	let ev                              = ERC1967ImplementationUpgraded.load(ERC1967ImplementationUpgradedId)
+	if (ev !== null)                    return
+	ev                                  = new ERC1967ImplementationUpgraded(ERC1967ImplementationUpgradedId)
+	ev.emitter                          = contract.id
+	ev.transaction                      = transactions.log(event).id
+	ev.timestamp                        = event.block.timestamp
+	ev.implementation                   = admin.id
 	ev.save()
 }

--- a/src/datasources/erc20.ts
+++ b/src/datasources/erc20.ts
@@ -28,14 +28,17 @@ import {
 } from '../fetch/erc20'
 
 export function handleTransfer(event: TransferEvent): void {
-	let contract   = fetchERC20(event.address)
-	let ev         = new ERC20Transfer(events.id(event))
-	ev.emitter     = contract.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.contract    = contract.id
-	ev.value       = decimals.toDecimals(event.params.value, contract.decimals)
-	ev.valueExact  = event.params.value
+	let ERC20TransferId  = events.id(event)
+	let ev               = ERC20Transfer.load(ERC20TransferId)
+	if (ev !== null)     return
+	let contract         = fetchERC20(event.address)
+	ev                   = new ERC20Transfer(ERC20TransferId)
+	ev.emitter           = contract.id
+	ev.transaction       = transactions.log(event).id
+	ev.timestamp         = event.block.timestamp
+	ev.contract          = contract.id
+	ev.value             = decimals.toDecimals(event.params.value, contract.decimals)
+	ev.valueExact        = event.params.value
 
 	if (event.params.from == Address.zero()) {
 		let totalSupply        = fetchERC20Balance(contract, null)

--- a/src/datasources/erc721.ts
+++ b/src/datasources/erc721.ts
@@ -40,14 +40,17 @@ export function handleTransfer(event: TransferEvent): void {
 		contract.save()
 		token.save()
 
-		let ev         = new ERC721Transfer(events.id(event))
-		ev.emitter     = contract.id
-		ev.transaction = transactions.log(event).id
-		ev.timestamp   = event.block.timestamp
-		ev.contract    = contract.id
-		ev.token       = token.id
-		ev.from        = from.id
-		ev.to          = to.id
+		let ERC721TransferId = events.id(event)
+		let ev               = ERC721Transfer.load(ERC721TransferId)
+		if (ev !== null)     return
+		ev                   = new ERC721Transfer(ERC721TransferId)
+		ev.emitter           = contract.id
+		ev.transaction       = transactions.log(event).id
+		ev.timestamp         = event.block.timestamp
+		ev.contract          = contract.id
+		ev.token             = token.id
+		ev.from              = from.id
+		ev.to                = to.id
 		ev.save()
 	}
 }

--- a/src/datasources/governor.ts
+++ b/src/datasources/governor.ts
@@ -62,13 +62,16 @@ export function handleProposalCreated(event: ProposalCreatedEvent): void {
 		call.save()
 	}
 
-	let ev         = new ProposalCreated(events.id(event))
-	ev.emitter     = governor.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.governor    = proposal.governor
-	ev.proposal    = proposal.id
-	ev.proposer    = proposal.proposer
+	let proposalCreatedId = events.id(event)
+	let ev                = ProposalCreated.load(proposalCreatedId)
+	if (ev !== null)      return
+	ev                    = new ProposalCreated(proposalCreatedId)
+	ev.emitter            = governor.id
+	ev.transaction        = transactions.log(event).id
+	ev.timestamp          = event.block.timestamp
+	ev.governor           = proposal.governor
+	ev.proposal           = proposal.id
+	ev.proposer           = proposal.proposer
 	ev.save()
 }
 
@@ -80,13 +83,16 @@ export function handleProposalQueued(event: ProposalQueuedEvent): void {
 	proposal.eta    = event.params.eta
 	proposal.save()
 
-	let ev         = new ProposalQueued(events.id(event))
-	ev.emitter     = governor.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.governor    = governor.id
-	ev.proposal    = proposal.id
-	ev.eta         = event.params.eta
+	let proposalQueuedId = events.id(event)
+	let ev               = ProposalQueued.load(proposalQueuedId)
+	if (ev !== null)     return
+	ev                   = new ProposalQueued(proposalQueuedId)
+	ev.emitter           = governor.id
+	ev.transaction       = transactions.log(event).id
+	ev.timestamp         = event.block.timestamp
+	ev.governor          = governor.id
+	ev.proposal          = proposal.id
+	ev.eta               = event.params.eta
 	ev.save()
 }
 
@@ -97,12 +103,15 @@ export function handleProposalExecuted(event: ProposalExecutedEvent): void {
 	proposal.executed = true
 	proposal.save()
 
-	let ev         = new ProposalExecuted(events.id(event))
-	ev.emitter     = governor.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.governor    = governor.id
-	ev.proposal    = proposal.id
+	let proposalExecutedId = events.id(event)
+	let ev                 = ProposalExecuted.load(proposalExecutedId)
+	if (ev !== null)       return
+	ev                     = new ProposalExecuted(proposalExecutedId)
+	ev.emitter             = governor.id
+	ev.transaction         = transactions.log(event).id
+	ev.timestamp           = event.block.timestamp
+	ev.governor            = governor.id
+	ev.proposal            = proposal.id
 	ev.save()
 }
 
@@ -113,12 +122,15 @@ export function handleProposalCanceled(event: ProposalCanceledEvent): void {
 	proposal.canceled = true
 	proposal.save()
 
-	let ev         = new ProposalCanceled(events.id(event))
-	ev.emitter     = governor.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.governor    = governor.id
-	ev.proposal    = proposal.id
+	let proposalCanceledId = events.id(event)
+	let ev                 = ProposalCanceled.load(proposalCanceledId)
+	if (ev !== null)       return
+	ev                     = new ProposalCanceled(proposalCanceledId)
+	ev.emitter             = governor.id
+	ev.transaction         = transactions.log(event).id
+	ev.timestamp           = event.block.timestamp
+	ev.governor            = governor.id
+	ev.proposal            = proposal.id
 	ev.save()
 }
 
@@ -136,15 +148,18 @@ export function handleVoteCast(event: VoteCastEvent): void {
 	receipt.reason  = event.params.reason
 	receipt.save()
 
-	let ev         = new VoteCast(events.id(event))
-	ev.emitter     = governor.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.governor    = governor.id
-	ev.proposal    = receipt.proposal
-	ev.support     = receipt.support
-	ev.receipt     = receipt.id
-	ev.voter       = receipt.voter
+	let voteCastId   = events.id(event)
+	let ev           = VoteCast.load(voteCastId)
+	if (ev !== null) return
+	ev               = new VoteCast(voteCastId)
+	ev.emitter       = governor.id
+	ev.transaction   = transactions.log(event).id
+	ev.timestamp     = event.block.timestamp
+	ev.governor      = governor.id
+	ev.proposal      = receipt.proposal
+	ev.support       = receipt.support
+	ev.receipt       = receipt.id
+	ev.voter         = receipt.voter
 	ev.save()
 }
 
@@ -164,14 +179,17 @@ export function handleVoteCastWithParams(event: VoteCastWithParamsEvent): void {
 	receipt.params  = event.params.params
 	receipt.save()
 
-	let ev         = new VoteCast(events.id(event))
-	ev.emitter     = governor.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.governor    = governor.id
-	ev.proposal    = receipt.proposal
-	ev.support     = receipt.support
-	ev.receipt     = receipt.id
-	ev.voter       = receipt.voter
+	let voteCastId   = events.id(event)
+	let ev           = VoteCast.load(voteCastId)
+	if (ev !== null) return
+	ev               = new VoteCast(voteCastId)
+	ev.emitter       = governor.id
+	ev.transaction   = transactions.log(event).id
+	ev.timestamp     = event.block.timestamp
+	ev.governor      = governor.id
+	ev.proposal      = receipt.proposal
+	ev.support       = receipt.support
+	ev.receipt       = receipt.id
+	ev.voter         = receipt.voter
 	ev.save()
 }

--- a/src/datasources/ownable.ts
+++ b/src/datasources/ownable.ts
@@ -25,12 +25,15 @@ export function handleOwnershipTransferred(event: OwnershipTransferredEvent): vo
 
 	contract.owner = owner.id
 	contract.save()
-
-	let ev         = new OwnershipTransferred(events.id(event))
-	ev.emitter     = contract.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.contract    = contract.id
-	ev.owner       = owner.id
+ 
+	let ownershipTransferredId = events.id(event)
+	let ev                     = OwnershipTransferred.load(ownershipTransferredId) 
+	if (ev !== null)           return
+	ev                         = new OwnershipTransferred(ownershipTransferredId)
+	ev.emitter                 = contract.id
+	ev.transaction             = transactions.log(event).id
+	ev.timestamp               = event.block.timestamp
+	ev.contract                = contract.id
+	ev.owner                   = owner.id
 	ev.save()
 }

--- a/src/datasources/pausable.ts
+++ b/src/datasources/pausable.ts
@@ -13,10 +13,6 @@ import {
 } from '@amxx/graphprotocol-utils'
 
 import {
-	fetchAccount,
-} from '../fetch/account'
-
-import {
 	fetchPausable,
 } from '../fetch/pausable'
 
@@ -25,12 +21,15 @@ export function handlePaused(event: PausedEvent): void {
 	contract.isPaused = true
 	contract.save()
 
-	let ev         = new Paused(events.id(event))
-	ev.emitter     = contract.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.contract    = contract.id
-	ev.isPaused    = true
+	let pausedId     = events.id(event)
+	let ev           = Paused.load(pausedId)
+	if (ev !== null) return
+	ev               = new Paused(pausedId)
+	ev.emitter       = contract.id
+	ev.transaction   = transactions.log(event).id
+	ev.timestamp     = event.block.timestamp
+	ev.contract      = contract.id
+	ev.isPaused      = true
 	ev.save()
 }
 
@@ -39,11 +38,14 @@ export function handleUnpaused(event: UnpausedEvent): void {
 	contract.isPaused = false
 	contract.save()
 
-	let ev         = new Paused(events.id(event))
-	ev.emitter     = contract.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.contract    = contract.id
-	ev.isPaused    = false
+	let pausedId      = events.id(event)
+	let ev            = Paused.load(pausedId)
+	if (ev !== null)  return
+	ev                = new Paused(pausedId)
+	ev.emitter        = contract.id
+	ev.transaction    = transactions.log(event).id
+	ev.timestamp      = event.block.timestamp
+	ev.contract       = contract.id
+	ev.isPaused       = false
 	ev.save()
 }

--- a/src/datasources/timelock.ts
+++ b/src/datasources/timelock.ts
@@ -48,13 +48,16 @@ export function handleCallScheduled(event: CallScheduledEvent): void {
 	call.data             = event.params.data
 	call.save()
 
-	let ev                = new TimelockOperationScheduled(events.id(event))
-	ev.emitter            = contract.id
-	ev.transaction        = transactions.log(event).id
-	ev.timestamp          = event.block.timestamp
-	ev.contract           = contract.id
-	ev.operation          = operation.id
-	ev.call               = call.id
+	let timelockOperationScheduledId = events.id(event)
+	let ev                           = TimelockOperationScheduled.load(timelockOperationScheduledId)
+	if (ev !== null)                 return
+	ev                               = new TimelockOperationScheduled(timelockOperationScheduledId)
+	ev.emitter                       = contract.id
+	ev.transaction                   = transactions.log(event).id
+	ev.timestamp                     = event.block.timestamp
+	ev.contract                      = contract.id
+	ev.operation                     = operation.id
+	ev.call                          = call.id
 	ev.save()
 }
 
@@ -65,13 +68,16 @@ export function handleCallExecuted(event: CallExecutedEvent): void {
 	operation.status      = "EXECUTED"
 	operation.save()
 
-	let ev                = new TimelockOperationExecuted(events.id(event))
-	ev.emitter            = contract.id
-	ev.transaction        = transactions.log(event).id
-	ev.timestamp          = event.block.timestamp
-	ev.contract           = contract.id
-	ev.operation          = operation.id
-	ev.call               = call.id
+	let timelockOperationExecutedId = events.id(event)
+	let ev                          = TimelockOperationExecuted.load(timelockOperationExecutedId)
+	if (ev !== null)                return
+	ev                              = new TimelockOperationExecuted(timelockOperationExecutedId)
+	ev.emitter                      = contract.id
+	ev.transaction                  = transactions.log(event).id
+	ev.timestamp                    = event.block.timestamp
+	ev.contract                     = contract.id
+	ev.operation                    = operation.id
+	ev.call                         = call.id
 	ev.save()
 }
 
@@ -81,23 +87,29 @@ export function handleCancelled(event: CancelledEvent): void {
 	operation.status      = "CANCELED"
 	operation.save()
 
-	let ev                = new TimelockOperationCancelled(events.id(event))
-	ev.emitter            = contract.id
-	ev.transaction        = transactions.log(event).id
-	ev.timestamp          = event.block.timestamp
-	ev.contract           = contract.id
-	ev.operation          = operation.id
+	let timelockOperationCancelledId = events.id(event)
+	let ev                           = TimelockOperationCancelled.load(timelockOperationCancelledId)
+	if (ev !== null)                 return
+	ev                               = new TimelockOperationCancelled(timelockOperationCancelledId)
+	ev.emitter                       = contract.id
+	ev.transaction                   = transactions.log(event).id
+	ev.timestamp                     = event.block.timestamp
+	ev.contract                      = contract.id
+	ev.operation                     = operation.id
 	ev.save()
 }
 
 export function handleMinDelayChange(event: MinDelayChangeEvent): void {
 	let contract          = fetchTimelock(event.address)
 
-	let ev                = new TimelockMinDelayChange(events.id(event))
-	ev.emitter            = contract.id
-	ev.transaction        = transactions.log(event).id
-	ev.timestamp          = event.block.timestamp
-	ev.contract           = contract.id
-	ev.delay              = event.params.newDuration
+	let timelockMinDelayChangeId = events.id(event)
+	let ev                       = TimelockMinDelayChange.load(timelockMinDelayChangeId)
+	if (ev !== null)             return
+	ev                           = new TimelockMinDelayChange(timelockMinDelayChangeId)
+	ev.emitter                   = contract.id
+	ev.transaction               = transactions.log(event).id
+	ev.timestamp                 = event.block.timestamp
+	ev.contract                  = contract.id
+	ev.delay                     = event.params.newDuration
 	ev.save()
 }

--- a/src/datasources/voting.ts
+++ b/src/datasources/voting.ts
@@ -34,15 +34,18 @@ export function handleDelegateChanged(event: DelegateChangedEvent): void {
 
 	delegation.save()
 
-	let ev          = new DelegateChanged(events.id(event))
-	ev.emitter      = contract.id
-	ev.transaction  = transactions.log(event).id
-	ev.timestamp    = event.block.timestamp
-	ev.delegation   = delegation.id
-	ev.contract     = contract.id
-	ev.delegator    = delegator.id
-	ev.fromDelegate = fromDelegate.id
-	ev.toDelegate   = toDelegate.id
+	let delegateChangedId = events.id(event)
+	let ev                = DelegateChanged.load(delegateChangedId)
+	if (ev !== null)      return
+	ev                    = new DelegateChanged(delegateChangedId)
+	ev.emitter            = contract.id
+	ev.transaction        = transactions.log(event).id
+	ev.timestamp          = event.block.timestamp
+	ev.delegation         = delegation.id
+	ev.contract           = contract.id
+	ev.delegator          = delegator.id
+	ev.fromDelegate       = fromDelegate.id
+	ev.toDelegate         = toDelegate.id
 	ev.save()
 }
 
@@ -58,14 +61,17 @@ export function handleDelegateVotesChanged(event: DelegateVotesChangedEvent): vo
 	total.save()
 	weigth.save()
 
-	let ev         = new DelegateVotesChanged(events.id(event))
-	ev.emitter     = contract.id
-	ev.transaction = transactions.log(event).id
-	ev.timestamp   = event.block.timestamp
-	ev.voteWeight  = weigth.id
-	ev.contract    = contract.id
-	ev.delegate    = delegate.id
-	ev.oldValue    = event.params.previousBalance
-	ev.newValue    = event.params.newBalance
+	let delegateVotesChangedId = events.id(event)
+	let ev                     = DelegateVotesChanged.load(delegateVotesChangedId)
+	if (ev !== null)           return
+	ev                         = new DelegateVotesChanged(delegateVotesChangedId)
+	ev.emitter                 = contract.id
+	ev.transaction             = transactions.log(event).id
+	ev.timestamp               = event.block.timestamp
+	ev.voteWeight              = weigth.id
+	ev.contract                = contract.id
+	ev.delegate                = delegate.id
+	ev.oldValue                = event.params.previousBalance
+	ev.newValue                = event.params.newBalance
 	ev.save()
 }

--- a/src/fetch/accesscontrol.ts
+++ b/src/fetch/accesscontrol.ts
@@ -18,15 +18,24 @@ import {
 } from '@amxx/graphprotocol-utils'
 
 export function fetchRole(id: Bytes): Role {
-	let role = new Role(id)
-	role.save()
+	let role = Role.load(id)
+
+	if (role === null) {
+		role   = new Role(id)
+		role.save()
+	}
+
 	return role
 }
 
 export function fetchAccessControl(address: Address): AccessControl {
-	let contract            = new AccessControl(address)
-	contract.asAccount      = address
-	contract.save()
+	let contract            = AccessControl.load(address)
+
+	if (contract === null) {
+		contract              = new AccessControl(address)
+		contract.asAccount    = address
+		contract.save()
+	}
 
 	let account             = fetchAccount(address)
 	account.asAccessControl = address

--- a/src/fetch/erc1155.ts
+++ b/src/fetch/erc1155.ts
@@ -31,9 +31,13 @@ export function replaceURI(uri: string, identifier: BigInt): string {
 }
 
 export function fetchERC1155(address: Address): ERC1155Contract {
-	let contract       = new ERC1155Contract(address)
-	contract.asAccount = address
-	contract.save()
+	let contract         = ERC1155Contract.load(address)
+
+	if (contract === null) {
+		contract           = new ERC1155Contract(address)
+		contract.asAccount = address
+		contract.save()
+	}
 
 	let account        = fetchAccount(address)
 	account.asERC1155  = address


### PR DESCRIPTION
Fixes #34 

## Description
This PR adds a check to avoid creating entities that already exist, so there are no unique key constraint issues. This **only applies to immutable entities**.

## Considerations
- Most of the `if (ev !== null) return` are unreachable code. However, there are some cases in which it is expected that we'll try to save an entity that's already saved, so having protection in all of them sounds like the right thing to me to avoid unexpected errors.
- Examples of common places where the `if (ev !== null) ...` will get triggered and is expected are:
  1. With `AccessControl`, it was being created each time we called `fetchAccessControl`, which is in every access control event handler
  2. With `Role`, there are several places calling `fetchRole` that created the same role each time.